### PR TITLE
[11.0] [IMP] Update currency_rate_update config view

### DIFF
--- a/currency_rate_update/models/res_config_settings.py
+++ b/currency_rate_update/models/res_config_settings.py
@@ -8,4 +8,6 @@ class ResConfigSettings(models.TransientModel):
     _inherit = 'res.config.settings'
 
     auto_currency_up = fields.Boolean(
-        related='company_id.auto_currency_up')
+        related='company_id.auto_currency_up',
+        help='Update exchange rates automatically'
+             'from currency_rate_update module.')

--- a/currency_rate_update/views/res_config_settings.xml
+++ b/currency_rate_update/views/res_config_settings.xml
@@ -10,12 +10,15 @@
         <field name="model">res.config.settings</field>
         <field name="inherit_id" ref="account.res_config_settings_view_form"/>
         <field name="arch" type="xml">
-            <field name="module_currency_rate_live" position="attributes">
-                <attribute name="invisible">1</attribute>
-            </field>
-            <field name="module_currency_rate_live" position="after">
+            <field name="module_currency_rate_live" position="before">
                 <field name="auto_currency_up" class="oe_inline"/>
             </field>
+            <label for="module_currency_rate_live" position="before">
+                <label for="auto_currency_up"/>
+                <div class="text-muted">
+                    Update exchange rates automatic from currency_rate_update module
+                </div>
+            </label>
         </field>
     </record>
 


### PR DESCRIPTION
Update accounting config view to show auto_currency_up field and label, and make enterprise version checkbox invisible.