### PR TITLE
FIX next_run to prevent update fail

### DIFF
--- a/currency_rate_update/models/currency_rate_update.py
+++ b/currency_rate_update/models/currency_rate_update.py
@@ -220,7 +220,7 @@ class CurrencyRateUpdateService(models.Model):
     @api.multi
     def run_currency_update(self):
         # Update currency at the given frequence
-        services = self.search([('next_run', '=', fields.Date.today())])
+        services = self.search([('next_run', '<=', fields.Date.today())])
         services.with_context(cron=True).refresh_currency()
 
     @api.model


### PR DESCRIPTION
If one day cron fails, then next_run is not updated, and refresh_currency will not be executed anymore