### PR TITLE
[IMP] Make the method get_exchange_rate overridable to adapt some special banks

### DIFF
--- a/currency_rate_update/README.rst
+++ b/currency_rate_update/README.rst
@@ -84,6 +84,8 @@ Contributors
 * Daniel Dico <ddico@oerp.ca> (BOC)
 * Dmytro Katyukha <firemage.dima@gmail.com>
 * Jesús Ventosinos Mayor <jesus@comunitea.com>
+* Duc, Dao Dong <duc.dd@komit-consulting.com> (https://komit-consulting.com)
+* Le Dinh Tien <tien.ld@komit-consulting.com> (https://komit-consulting.com)
 
 Maintainer
 ----------

--- a/currency_rate_update/__manifest__.py
+++ b/currency_rate_update/__manifest__.py
@@ -2,7 +2,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 {
     "name": "Currency Rate Update",
-    "version": "11.0.1.0.0",
+    "version": "11.0.1.0.1",
     "author": "Camptocamp,Odoo Community Association (OCA)",
     "website": "http://camptocamp.com",
     "license": "AGPL-3",

--- a/currency_rate_update/tests/__init__.py
+++ b/currency_rate_update/tests/__init__.py
@@ -1,2 +1,3 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 from . import test_currency_rate_update
+from . import test_service_rate_dictionary_update

--- a/currency_rate_update/tests/test_service_rate_dictionary_update.py
+++ b/currency_rate_update/tests/test_service_rate_dictionary_update.py
@@ -1,0 +1,106 @@
+# © 2019 Duc, Dao Dong
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from ..services.currency_getter_interface import CurrencyGetterInterface
+
+
+class TestServiceRateDirectUpdate(CurrencyGetterInterface):
+
+    code = 'TSRDU'
+    name = 'Test Service Rate Direct Update'
+    supported_currency_array = ["EUR", "USD"]
+
+    def rate_retrieve(self):
+        res = {}
+        res['rate_currency'] = 1.13
+        return res
+
+    def get_updated_currency(self, currency_array, main_currency,
+                             max_delta_days):
+        if main_currency in currency_array:
+            currency_array.remove(main_currency)
+        if main_currency != 'EUR':
+            main_curr_data = self.rate_retrieve()
+        for curr in currency_array:
+            self.validate_cur(curr)
+            if curr == 'EUR':
+                rate = 1 / main_curr_data['rate_currency']
+            else:
+                curr_data = self.rate_retrieve()
+                if main_currency == 'EUR':
+                    rate = curr_data['rate_currency']
+                else:
+                    rate = (curr_data['rate_currency'] /
+                            main_curr_data['rate_currency'])
+            self.updated_currency[curr] = {
+                'direct': rate
+            }
+        return self.updated_currency, self.log_info
+
+
+class TestServiceRateInvertedUpdate(CurrencyGetterInterface):
+
+    code = 'TSRIU'
+    name = 'Test Service Rate Inverted Update'
+    supported_currency_array = ["EUR", "USD"]
+
+    def rate_retrieve(self):
+        res = {}
+        res['rate_currency'] = 1.13
+        return res
+
+    def get_updated_currency(self, currency_array, main_currency,
+                             max_delta_days):
+        if main_currency in currency_array:
+            currency_array.remove(main_currency)
+        if main_currency != 'EUR':
+            main_curr_data = self.rate_retrieve()
+        for curr in currency_array:
+            self.validate_cur(curr)
+            if curr == 'EUR':
+                rate = 1 / main_curr_data['rate_currency']
+            else:
+                curr_data = self.rate_retrieve()
+                if main_currency == 'EUR':
+                    rate = curr_data['rate_currency']
+                else:
+                    rate = (curr_data['rate_currency'] /
+                            main_curr_data['rate_currency'])
+            self.updated_currency[curr] = {
+                'inverted': 1/rate
+            }
+        return self.updated_currency, self.log_info
+
+
+class TestServiceWrongRateUpdate(CurrencyGetterInterface):
+
+    code = 'TSWRU'
+    name = 'Test Service Wrong Rate Update'
+    supported_currency_array = ["EUR", "USD"]
+
+    def rate_retrieve(self):
+        res = {}
+        res['rate_currency'] = 1.13
+        return res
+
+    def get_updated_currency(self, currency_array, main_currency,
+                             max_delta_days):
+        if main_currency in currency_array:
+            currency_array.remove(main_currency)
+        if main_currency != 'EUR':
+            main_curr_data = self.rate_retrieve()
+        for curr in currency_array:
+            self.validate_cur(curr)
+            if curr == 'EUR':
+                rate = 1 / main_curr_data['rate_currency']
+            else:
+                curr_data = self.rate_retrieve()
+                if main_currency == 'EUR':
+                    rate = curr_data['rate_currency']
+                else:
+                    rate = (curr_data['rate_currency'] /
+                            main_curr_data['rate_currency'])
+            self.updated_currency[curr] = {
+                'rate': rate
+            }
+        return self.updated_currency, self.log_info


### PR DESCRIPTION
Original issue from module [currency_rate_update_vn_VCB](https://github.com/OCA/l10n-vietnam/pull/8):

[VCB service](http://www.vietcombank.com.vn/ExchangeRates/ExrateXML.aspx) already provided the rates as inverted compared with main currency (VND).

So when using this module along with `currency_rate_inverted`, it does not work properly with the inverted rate (inverts the rates that were already inverted).

By providing the overridable mechanism, we'll allow people to handle some specific cases for specific bank services easier.

