### PR TITLE
[11.0][FIX] account_fx_spot: fix test 

### DIFF
--- a/account_fx_spot/tests/test_account_fx_spot.py
+++ b/account_fx_spot/tests/test_account_fx_spot.py
@@ -34,7 +34,6 @@ class TestAccountFxSpot(common.TransactionCase):
                 "name": "Journal Company Currency Test",
                 "code": "TESTC",
                 "type": "bank",
-                "currency_id": self.company.currency_id.id,
                 "default_debit_account_id": acc_curr_c.id,
                 "default_credit_account_id": acc_curr_c.id,
             })
@@ -101,7 +100,8 @@ class TestAccountFxSpot(common.TransactionCase):
             "payment_type": payment_type,
             "partner_type": partner_type,
             "journal_id": journal.id,
-            "currency_id": journal.currency_id.id,
+            "currency_id": journal.currency_id.id or
+            self.company.currency_id.id,
             "amount": amount,
             "payment_method_id": payment_method.id,
         }


### PR DESCRIPTION
Fix test  since now it is not possible to set the same currency in a journal as the company's one. (ref: https://github.com/odoo/odoo/commit/22f0da809e84618901b7ca4b78582abd64c03c55)

This fix does not need to be ported to v12.

cc @angelmoya @pedrobaeza 

@Eficent