### PR TITLE
[12.0][IMP] currency_rate_update for non EUR companies

### DIFF
--- a/currency_rate_update/__manifest__.py
+++ b/currency_rate_update/__manifest__.py
@@ -4,7 +4,7 @@
 
 {
     'name': 'Currency Rate Update',
-    'version': '12.0.1.1.2',
+    'version': '12.0.1.2.0',
     'author':
         'Camptocamp, '
         'Brainbean Apps, '

--- a/currency_rate_update/models/res_currency_rate_provider.py
+++ b/currency_rate_update/models/res_currency_rate_provider.py
@@ -25,6 +25,10 @@ class ResCurrencyRateProvider(models.Model):
         required=True,
         default=lambda self: self._default_company_id(),
     )
+    currency_name = fields.Char(
+        string='Currency Name',
+        related='company_id.currency_id.name'
+    )
     active = fields.Boolean(
         default=True,
     )

--- a/currency_rate_update/tests/test_currency_rate_update.py
+++ b/currency_rate_update/tests/test_currency_rate_update.py
@@ -32,6 +32,7 @@ class TestCurrencyRateUpdate(common.SavepointCase):
         self.today = fields.Date.today()
         self.eur_currency = self.env.ref('base.EUR')
         self.usd_currency = self.env.ref('base.USD')
+        self.chf_currency = self.env.ref('base.CHF')
         self.company = self.Company.create({
             'name': 'Test company',
             'currency_id': self.eur_currency.id,
@@ -204,3 +205,14 @@ class TestCurrencyRateUpdate(common.SavepointCase):
             self.ecb_provider.next_run,
             date(2019, 7, 8)
         )
+
+    def test_foreign_base_currency(self):
+        self.company.currency_id = self.chf_currency
+        self.test_update_ECB_today()
+        self.test_update_ECB_month()
+        self.test_update_ECB_year()
+        self.test_update_ECB_scheduled()
+        self.test_update_ECB_no_base_update()
+        self.test_update_ECB_sequence()
+        self.test_update_ECB_weekend()
+        self.company.currency_id = self.eur_currency

--- a/currency_rate_update/views/res_currency_rate_provider.xml
+++ b/currency_rate_update/views/res_currency_rate_provider.xml
@@ -44,6 +44,11 @@
                     <group name="options">
                         <group>
                             <field name="service"/>
+                            <field name="currency_name" invisible="1"/>
+                            <div attrs="{'invisible':['|',('service','!=','ECB'),('currency_name','=','EUR')]}" class="alert alert-warning" colspan="2" role="alert">
+                              <strong>! </strong>You are using European Central Bank exchange rate service with a base currency different from EUR.<br/>
+                              As long as the European Central Bank only provides exchange rates based on EUR, other foreign currency rates are recalculated and might differ from real rates.
+                            </div>
                         </group>
                         <group groups="base.group_multi_company">
                             <field name="company_id"/>


### PR DESCRIPTION
That PR reintroduces the v10 and v11 behavior by letting companies to use European Central Bank for other currencies than EUR.
If another currency is used as base currency, an inverted calcuation on rates is done.
This might require more investigation on the accuracy of the calculation for foreign currencies between them.
This should fix https://github.com/OCA/currency/issues/70 but discussion on introducing inverted calculation in core is still open.