### PR TITLE
[FIX] currency_rate_update: Prevent last_successful_run update if all…

### DIFF
--- a/currency_rate_update/data/cron.xml
+++ b/currency_rate_update/data/cron.xml
@@ -3,12 +3,12 @@
     Copyright 2019 Brainbean Apps (https://brainbeanapps.com)
     License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 -->
-<odoo>
+<odoo noupdate="1">
 
     <record model="ir.cron" id="ir_cron_currency_rates_update_every_day">
         <field name="name">Currency Rates Update (OCA) daily</field>
-        <field name="interval_number">1</field>
-        <field name="interval_type">days</field>
+        <field name="interval_number">12</field>
+        <field name="interval_type">hours</field>
         <field name="numbercall">-1</field>
         <field name="state">code</field>
         <field name="nextcall" >2019-01-01 00:01:00</field>

--- a/currency_rate_update/models/res_currency_rate_provider_ECB.py
+++ b/currency_rate_update/models/res_currency_rate_provider_ECB.py
@@ -18,6 +18,12 @@ class ResCurrencyRateProviderECB(models.Model):
         selection_add=[('ECB', 'European Central Bank')],
     )
 
+    @api.model
+    def _get_close_time(self):
+        if self.service == 'ECB':
+            return 17
+        return super()._get_close_time()
+
     @api.multi
     def _get_supported_currencies(self):
         self.ensure_one()

--- a/currency_rate_update/readme/CONTRIBUTORS.rst
+++ b/currency_rate_update/readme/CONTRIBUTORS.rst
@@ -20,3 +20,9 @@
 * Dmytro Katyukha <firemage.dima@gmail.com>
 * Jesús Ventosinos Mayor <jesus@comunitea.com>
 * Alexey Pelykh <alexey.pelykh@brainbeanapps.com>
+
+* `Tecnativa <https://www.tecnativa.com>`_:",
+
+  * Víctor Martínez
+  * Pedro M. Baeza
+


### PR DESCRIPTION
Prevent last_successful_run update if all records not create to every currencies and dates needed.

**Example**: BCE update rate in 14:00+01:00 and if we define ir_cron to 02:00 hour, read all the info but not exists records from some currencies from today but updated last_successful_run field and NOT save any records to some currencies and dates. Tomorrow the same problem and without any record save about currency rate.

**Solution**: Add method `_get_close_date` that allow define close hour. If defined, only when hour is greater is executed update for this provider.

**Issue related**: https://github.com/OCA/currency/issues/84

Please, @Yajo and @pedrobaeza   review it

@Tecnativa TT25624