### PR TITLE
[13.0][FIX]Multicompany behaviour fix

### DIFF
--- a/currency_rate_inverted/models/res_currency.py
+++ b/currency_rate_inverted/models/res_currency.py
@@ -1,3 +1,4 @@
+# Copyright 2021 Sergej Ruzki. ReSuSolutions.
 # Copyright 2018 ForgeFlow, S.L.
 # Copyright 2015 Techrifiv Solutions Pte Ltd
 # Copyright 2015 Statecraft Systems Pte Ltd
@@ -16,6 +17,9 @@ class ResCurrency(models.Model):
     @api.model
     def _get_conversion_rate(self, from_currency, to_currency, company, date):
         rate = super()._get_conversion_rate(from_currency, to_currency, company, date)
+
+        from_currency = from_currency.with_context(force_company=company.id)
+        to_currency = to_currency.with_context(force_company=company.id)
 
         if not from_currency.rate_inverted and not to_currency.rate_inverted:
             return rate

--- a/currency_rate_inverted/readme/CONTRIBUTORS.rst
+++ b/currency_rate_inverted/readme/CONTRIBUTORS.rst
@@ -7,3 +7,4 @@
   * Alexey Pelykh <alexey.pelykh@corphub.eu>
 
 * Pimolnat Suntian <pimolnats@ecosoft.co.th>
+* SkiBY (Sergej Ruzki <sergei.ruzki@gmail.com>)


### PR DESCRIPTION
As we have company_dependent attribute, when we don't force context change, there will can be an error if you use multicompany.

All the convertions if user is in another active company will be done by 'current' company and don't like it should be via attributes.