### PR TITLE
[12.0][IMP] currency_rate_update_oxr: optional end-of-day exchange rates

### DIFF
--- a/currency_rate_update_oxr/models/res_company.py
+++ b/currency_rate_update_oxr/models/res_company.py
@@ -10,3 +10,7 @@ class ResCompany(models.Model):
     openexchangerates_app_id = fields.Char(
         string='OpenExchangeRates.org App ID',
     )
+    openexchangerates_eod_rates = fields.Boolean(
+        string='End-of-day rates',
+        help='Yesterday\'s end-of-day rates will be used for today.',
+    )

--- a/currency_rate_update_oxr/models/res_config_settings.py
+++ b/currency_rate_update_oxr/models/res_config_settings.py
@@ -12,3 +12,9 @@ class ResConfigSettings(models.TransientModel):
         related='company_id.openexchangerates_app_id',
         readonly=False,
     )
+    openexchangerates_eod_rates = fields.Boolean(
+        string='End-of-day rates',
+        related='company_id.openexchangerates_eod_rates',
+        readonly=False,
+        help='Yesterday\'s end-of-day rates will be used for today.',
+    )

--- a/currency_rate_update_oxr/models/res_currency_rate_provider_OXR.py
+++ b/currency_rate_update_oxr/models/res_currency_rate_provider_OXR.py
@@ -67,11 +67,14 @@ class ResCurrencyRateProviderOXR(models.Model):
             data_date = datetime.utcfromtimestamp(data['timestamp']).date()
             if eod_rates and data_date != date:
                 raise UserError(
-                    "Exchange rate from incorrect date received. Got {data_date}, expected {date}".format(
+                    "Exchange rate from incorrect date received. "
+                    "Got {data_date}, expected {date}".format(
                         data_date=data_date, date=date
                     )
                 )
-            date_content = content[(date + timedelta(days=1) if eod_rates else date).isoformat()]
+            date_content = content[(
+                date + timedelta(days=1) if eod_rates else date
+            ).isoformat()]
             if 'rates' in data:
                 for currency, rate in data['rates'].items():
                     date_content[currency] = rate

--- a/currency_rate_update_oxr/tests/test_currency_rate_update_oxr.py
+++ b/currency_rate_update_oxr/tests/test_currency_rate_update_oxr.py
@@ -78,7 +78,8 @@ class TestResCurrencyRateProviderOXR(common.TransactionCase):
         else:
             currency = self.eur_currency
 
-        # If the mocked currency is the same as the company currency it wil not be created.
+        # If the mocked currency is the same as the company currency
+        # it wil not be created.
         rates = self.CurrencyRate.search([
             ('currency_id', '=', currency.id),
         ], limit=1)

--- a/currency_rate_update_oxr/views/res_config_settings.xml
+++ b/currency_rate_update_oxr/views/res_config_settings.xml
@@ -26,6 +26,12 @@
                             </div>
                         </div>
                     </div>
+                    <div class="o_setting_left_pane">
+                        <field name="openexchangerates_eod_rates"/>
+                    </div>
+                    <div class="o_setting_right_pane">
+                        <label for="openexchangerates_eod_rates"/>
+                    </div>
                 </div>
             </xpath>
         </field>


### PR DESCRIPTION
Adds an option to the settings to use the end-of-day exchange rates for openexchangerates.org.
This is to prevent mismatching currencies when using multi-company and for any reason pulling of exchange rates is delayed. Such a delay would cause today's latest value to be used, which can then be different across different provider records (in the case of multi-company). The (optional) alternative proposed here will use yesterday's end-of-day rates for today's rates.

During testing I had an issue where my local version of Odoo would create a company with currency euro instead of us dollar. I've added a slight change as well to avoid tests breaking when that happens.