### PR TITLE
[12.0][ADD] OD-1465: currency_rate_check

### DIFF
--- a/currency_rate_check/__init__.py
+++ b/currency_rate_check/__init__.py
@@ -1,0 +1,4 @@
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from . import models
+from . import wizards

--- a/currency_rate_check/__manifest__.py
+++ b/currency_rate_check/__manifest__.py
@@ -1,0 +1,23 @@
+# Copyright 2021 VanMoof (<https://vanmoof.com>)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+{
+    'name': 'Currency Rate Check',
+    'version': '12.0.1.0.0',
+    'author':
+        'VanMoof, '
+        'Odoo Community Association (OCA)',
+    'website': 'https://github.com/OCA/currency',
+    'license': 'AGPL-3',
+    'category': 'Financial Management/Configuration',
+    'summary': 'Check exchange rates using OCA modules',
+    'depends': [
+        'currency_rate_update',
+    ],
+    'data': [
+        'security/ir.model.access.csv',
+        'views/account_move_line_currency_check.xml',
+        'wizards/res_currency_rate_check_wizard.xml',
+    ],
+    'installable': True,
+}

--- a/currency_rate_check/models/__init__.py
+++ b/currency_rate_check/models/__init__.py
@@ -1,0 +1,6 @@
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from . import account_move
+from . import account_move_line
+from . import account_move_line_currency_check
+from . import res_currency_rate

--- a/currency_rate_check/models/account_move.py
+++ b/currency_rate_check/models/account_move.py
@@ -1,0 +1,19 @@
+# Copyright 2021 VanMoof (<https://vanmoof.com>)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+from odoo import api, models
+
+# put this object into the context key '__bypass_update_checks' to disable
+# the AccountMove _check_lock_date and the AccountMoveLine _update_check
+bypass_update_checks = object()
+
+
+class AccountMove(models.Model):
+    _inherit = 'account.move'
+
+    @api.multi
+    def _check_lock_date(self):
+        """Do not raise when the entry is prior to the lock date if 'bypass_update_checks'
+        is True in the context."""
+        if self._context.get('__bypass_update_checks', False) == bypass_update_checks:
+            return True
+        return super()._check_lock_date()

--- a/currency_rate_check/models/account_move_line.py
+++ b/currency_rate_check/models/account_move_line.py
@@ -1,0 +1,17 @@
+# Copyright 2021 VanMoof (<https://vanmoof.com>)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+from odoo import api, models
+
+from .account_move import bypass_update_checks
+
+
+class AccountMoveLine(models.Model):
+    _inherit = 'account.move.line'
+
+    @api.multi
+    def _update_check(self):
+        """Do not raise when the entry is posted or reconciled if 'bypass_update_checks'
+        is True in the context."""
+        if self._context.get('__bypass_update_checks', False) == bypass_update_checks:
+            return True
+        return super()._update_check()

--- a/currency_rate_check/models/account_move_line_currency_check.py
+++ b/currency_rate_check/models/account_move_line_currency_check.py
@@ -75,9 +75,9 @@ class AccountMoveLineCurrencyCheck(models.Model):
         wizard and the exchange rates in Odoo."""
         precision = self.env['decimal.precision'].precision_get('Account')
         domain = [
-                ('date', '>=', date_from),
-                ('date', '<=', date_to),
-                ('company_id', '=', self.env.user.company_id.id),
+            ('date', '>=', date_from),
+            ('date', '<=', date_to),
+            ('company_id', '=', self.env.user.company_id.id),
         ]
         if ref:
             domain.extend([

--- a/currency_rate_check/models/account_move_line_currency_check.py
+++ b/currency_rate_check/models/account_move_line_currency_check.py
@@ -1,0 +1,276 @@
+# Copyright 2021 VanMoof (<https://vanmoof.com>)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+from odoo import fields, models, api, _
+from odoo.tools import float_compare, formatLang
+from .account_move import bypass_update_checks
+
+
+class AccountMoveLineCurrencyCheck(models.Model):
+    _name = 'account.move.line.currency.check'
+    _inherits = {'account.move.line': 'line_id'}
+    _description = 'Journal Item Currency Check Wizard'
+    _rec_name = 'line_id'
+
+    line_id = fields.Many2one(
+        comodel_name='account.move.line',
+        string='Journal Item',
+        required=True,
+        ondelete='CASCADE',
+        index=True,
+    )
+    amount = fields.Monetary(
+        string='Amount Company Currency',
+        help='Amount Currency converted to company currency '
+             '(this will replace Debit or Credit with the '
+             '"Copy Amount Company Currency to debit/credit" button)',
+        currency_field='company_currency_id',
+        compute='_compute_amount', store=False,
+    )
+    alt_amount_currency = fields.Monetary(
+        string='Amount Partner Currency',
+        help='Debit or credit converted to partner currency '
+             '(this will replace Amount Currency with the '
+             '"Copy Amount Partner Currency to Amount Currency" button)',
+        currency_field='currency_id',
+        compute='_compute_alt_amount_currency', store=False,
+    )
+    rate_partner = fields.Many2one('res.currency.rate')
+    rate_company = fields.Many2one('res.currency.rate')
+
+    _sql_constraints = [
+        ('line_id_uniq', 'UNIQUE(line_id)',
+         _('The reference to journal items must be unique.')),
+    ]
+
+    @api.one
+    def _compute_amount(self):
+        company_currency_id = self.account_id.company_id.currency_id
+        self.amount = self.currency_id._convert(
+            from_amount=self.amount_currency,
+            to_currency=company_currency_id,
+            company=self.company_id,
+            date=self.date
+        )
+
+    @api.one
+    def _compute_alt_amount_currency(self):
+        sign = (1, -1)[self.amount_currency < 0]
+        if self.debit:
+            from_amount = self.debit * sign
+        elif self.credit:
+            from_amount = self.credit * sign
+        else:
+            from_amount = 0
+        self.alt_amount_currency = self.company_currency_id._convert(
+            from_amount=from_amount,
+            to_currency=self.currency_id,
+            company=self.company_id,
+            date=self.date
+        )
+
+    @api.model_cr
+    def action_update_check_lines(self, date_from, date_to, line_limit, ref):
+        """Upsert journal items into account.move.line.currency.check if they have
+        amounts that do not match up according to the parameters received from the
+        wizard and the exchange rates in Odoo."""
+        precision = self.env['decimal.precision'].precision_get('Account')
+        domain = [
+                ('date', '>=', date_from),
+                ('date', '<=', date_to),
+                ('company_id', '=', self.env.user.company_id.id),
+        ]
+        if ref:
+            domain.extend([
+                ('ref', 'ilike', ref)
+            ])
+        moves = self.env['account.move'].search(domain)
+        moves = moves.filtered(lambda move: len(move.line_ids) <= line_limit)
+        lines = moves.mapped('line_ids')
+        create_values = []
+        write_values = []
+        for line in lines:
+            # Even if we already have the line in the table, recompute the amounts
+            # and perform an upsert if they don't match.
+            company_currency_id = line.account_id.company_id.currency_id
+            if (
+                line.currency_id
+                and company_currency_id
+                and line.currency_id != company_currency_id
+                and line.date
+            ):
+                # Note: _convert will take the most recent (older) date if one for the
+                # given date does not exist. To rephrase: a rate that is newer than the
+                # requested date will not be used.
+                amount = line.currency_id._convert(
+                    from_amount=line.amount_currency,
+                    to_currency=company_currency_id,
+                    company=line.company_id,
+                    date=line.date
+                )
+                # Check lines if the converted amount_currency does not match up with
+                # debit or credit
+                if (
+                    amount > 0 and float_compare(
+                        line.debit, abs(amount), precision_digits=precision)
+                ) or (
+                    amount < 0 and float_compare(
+                        line.credit, abs(amount), precision_digits=precision
+                    )
+                ):
+                    domain = [
+                        ('name', '=', line.date),
+                        ('company_id', '=', self.env.user.company_id.id),
+                    ]
+                    rate_partner = self.env['res.currency.rate'].search(
+                        domain + [('currency_id', '=', line.currency_id.id)]
+                    )
+                    rate_company = self.env['res.currency.rate'].search(
+                        domain + [('currency_id', '=', line.company_currency_id.id)]
+                    )
+                    values = {
+                        'line_id': line.id,
+                        'rate_partner': rate_partner.id,
+                        'rate_company': rate_company.id,
+                    }
+                    check_line = self.search([('line_id', '=', line.id)])
+                    if len(check_line) > 0:
+                        check_line.write(values)
+                        write_values.append(values)
+                    else:
+                        create_values.append(values)
+        if create_values:
+            self.create(create_values)
+        return write_values + create_values
+
+    @api.model
+    def _get_converted_amount(
+        self, move, line, from_amount, from_currency, to_currency
+    ):
+        if len(move.line_ids) > 2:
+            raise NotImplementedError(
+                _(
+                    "Recomputing Entries with more than two Items is not yet "
+                    "implemented."
+                )
+            )
+        assert (
+            move.line_ids[0].credit == move.line_ids[1].debit
+            and move.line_ids[1].credit == move.line_ids[0].debit
+        )
+        amount = abs(from_currency._convert(
+            from_amount=from_amount,
+            to_currency=to_currency,
+            company=line.company_id,
+            date=line.date)
+        )
+        return amount
+
+    @api.model
+    def _message_post(self, env, move, currency_company, amount, old_amount):
+        """Post a message with the old and new amount to the invoices related to the
+        given move. The symbol is determined based on whether the partner or company
+        currency is used (indicated here with the currency_company bool."""
+        link_template = '<a href="#" data-oe-model="%s" data-oe-id="%d">%s</a>'
+        move.mapped('line_ids').mapped(lambda l: l.invoice_id.message_post(
+            body=_(
+                "{link} has been recomputed from {old_amount} to "
+                "{new_amount} because the exchange rate was "
+                "updated."
+            ).format(
+                link=link_template % (
+                    l._name, l.id, l.display_name or _('Unnamed')
+                    ),
+                old_amount=formatLang(
+                    env,
+                    value=abs(old_amount),
+                    currency_obj=l.currency_id
+                    ) if currency_company
+                else formatLang(
+                    env,
+                    value=old_amount,
+                    currency_obj=l.company_currency_id
+                    ),
+                new_amount=formatLang(
+                    env,
+                    value=abs(amount),
+                    currency_obj=l.currency_id
+                    ) if currency_company
+                else formatLang(
+                    env,
+                    value=abs(amount),
+                    currency_obj=l.company_currency_id
+                    )
+            )
+        ))
+
+    @api.multi
+    def action_rebase_currency_partner(self):
+        """Recompute debit or credit based on the value of amount_currency."""
+        moves = self.mapped('move_id')
+        to_unlink = self.browse()
+        for move in moves:
+            line = move.line_ids[0]
+            company_currency_id = line.account_id.company_id.currency_id
+            amount = self._get_converted_amount(
+                move=move,
+                line=line,
+                from_amount=line.amount_currency,
+                from_currency=line.currency_id,
+                to_currency=company_currency_id
+            )
+
+            old_amount = move.line_ids[0].credit or move.line_ids[0].debit
+            move.with_context(__bypass_update_checks=bypass_update_checks).write({
+                'line_ids': [
+                    (1, move.line_ids[0].id, {
+                        'debit': amount if move.line_ids[0].debit > 0 else 0,
+                        'credit': amount if move.line_ids[0].credit > 0 else 0,
+                    }),
+                    (1, move.line_ids[1].id, {
+                        'debit': amount if move.line_ids[1].debit > 0 else 0,
+                        'credit': amount if move.line_ids[1].credit > 0 else 0,
+                    })
+                ],
+            })
+            to_unlink |= self.search([('line_id', 'in', move.line_ids.ids)])
+
+            self._message_post(self.env, move, False, amount, old_amount)
+        to_unlink.unlink()
+
+    @api.multi
+    def action_rebase_currency_company(self):
+        """Recompute amount_currency based on the value of debit or credit."""
+        to_unlink = self.browse()
+        moves = self.mapped('move_id')
+        for move in moves:
+            if move.line_ids[0].debit:
+                debit_line = move.line_ids[0]
+            else:
+                debit_line = move.line_ids[1]
+            company_currency_id = debit_line.account_id.company_id.currency_id
+            amount = self._get_converted_amount(
+                move=move,
+                line=debit_line,
+                from_amount=debit_line.debit,
+                from_currency=company_currency_id,
+                to_currency=debit_line.currency_id
+            )
+
+            old_amount = move.line_ids[0].amount_currency
+            move.with_context(__bypass_update_checks=bypass_update_checks).write({
+                'line_ids': [
+                    (1, move.line_ids[0].id, {
+                        'amount_currency':
+                        amount if move.line_ids[0].amount_currency > 0
+                        else amount * -1,
+                    }),
+                    (1, move.line_ids[1].id, {
+                        'amount_currency':
+                        amount if move.line_ids[1].amount_currency > 0
+                        else amount * -1,
+                    })
+                ],
+            })
+            to_unlink |= self.search([('line_id', 'in', move.line_ids.ids)])
+            self._message_post(self.env, move, True, amount, old_amount)
+        to_unlink.unlink()

--- a/currency_rate_check/models/res_currency_rate.py
+++ b/currency_rate_check/models/res_currency_rate.py
@@ -1,0 +1,24 @@
+# Copyright 2021 VanMoof (<https://vanmoof.com>)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import models, api
+from odoo.tools import misc
+
+
+class ResCurrencyRate(models.Model):
+    _inherit = "res.currency.rate"
+
+    @api.multi
+    def name_get(self):
+        """Override to show the rate and date"""
+        res = []
+        if self.env.context.get('rate_check_name_get', False):
+            for record in self:
+                rate_date = misc.format_date(self.env, record.name)
+                res.append(
+                    (record.id, '{rate} ({rate_date})'.format(
+                        rate=record.rate, rate_date=rate_date
+                    ))
+                )
+            return res
+        return super(ResCurrencyRate, self).name_get()

--- a/currency_rate_check/readme/CONTRIBUTORS.rst
+++ b/currency_rate_check/readme/CONTRIBUTORS.rst
@@ -1,0 +1,1 @@
+* Kevin Graveman <kevin.graveman@vanmoof.com> (https://www.vanmoof.com)

--- a/currency_rate_check/readme/DESCRIPTION.rst
+++ b/currency_rate_check/readme/DESCRIPTION.rst
@@ -1,0 +1,1 @@
+This module allows you to make corrections to the Amount Currency and Debit/Credit fields of Journal Items based on the exchange rates loaded in Odoo.

--- a/currency_rate_check/readme/USAGE.rst
+++ b/currency_rate_check/readme/USAGE.rst
@@ -1,0 +1,17 @@
+To check if Journal Items's Amount Currency and Debit or Credit lines match based
+on the exchange rates currently in Odoo:
+
+# Go to *Invoicing > Configuration > Currency Rates Providers*
+# Select a provider
+# Click *Action > Check Rates Wizard*
+# Read the instructions and fill in the form and click *Check*
+
+To apply corrections from Amount Company Currency to Debit/Credit:
+
+# Select Journal Items
+# Click *Action > Copy Amount Company Currency to debit/credit*
+
+To apply corrections from Amount Partner Currency to Amount Currency:
+
+# Select Journal Items
+# Click *Action > Copy Amount Partner Currency to Amount Currency*

--- a/currency_rate_check/security/ir.model.access.csv
+++ b/currency_rate_check/security/ir.model.access.csv
@@ -1,0 +1,3 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_res_currency_rate_check_service_admin,res.currency.check,model_account_move_line_currency_check,base.group_system,1,1,1,1
+access_res_currency_rate_check_service_manager,res.currency.check,model_account_move_line_currency_check,account.group_account_manager,1,0,0,0

--- a/currency_rate_check/tests/__init__.py
+++ b/currency_rate_check/tests/__init__.py
@@ -1,0 +1,3 @@
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from . import test_currency_rate_update

--- a/currency_rate_check/tests/test_currency_rate_update.py
+++ b/currency_rate_check/tests/test_currency_rate_update.py
@@ -38,8 +38,14 @@ class TestCurrencyRateUpdate(account_test_no_chart.TestAccountNoChartCommon):
             ],
         })
         self.rates = self.env['res.currency.rate'].create([
-            {'currency_id': self.eur_currency.id},
-            {'currency_id': self.jpy_currency.id},
+            {
+                'currency_id': self.eur_currency.id,
+                'rate': 0.87
+            },
+            {
+                'currency_id': self.jpy_currency.id,
+                'rate': 111.73
+            },
         ])
         self.currency_check_obj = self.env['account.move.line.currency.check']
         values = []
@@ -80,13 +86,22 @@ class TestCurrencyRateUpdate(account_test_no_chart.TestAccountNoChartCommon):
             self.currency_checks.mapped('move_id')
         self.assertEqual(
             self.move.line_ids[0].debit or self.move.line_ids[0].credit,
-            abs(self.move.line_ids[0].amount_currency)
+            abs(self.move.line_ids[0].currency_id._convert(
+                self.move.line_ids[0].amount_currency,
+                self.move.line_ids[0].company_currency_id,
+                self.move.line_ids[0].company_id, self.today
+            ))
         )
         self.assertEqual(
             self.move.line_ids[1].debit or self.move.line_ids[1].credit,
-            abs(self.move.line_ids[1].amount_currency)
+            abs(self.move.line_ids[1].currency_id._convert(
+                self.move.line_ids[1].amount_currency,
+                self.move.line_ids[1].company_currency_id,
+                self.move.line_ids[1].company_id, self.today
+            ))
         )
 
+        # Do the same thing but for action_rebase_currency_company
         for line in self.move.line_ids:
             if line.debit > 0:
                 line.debit += 50.0
@@ -107,9 +122,17 @@ class TestCurrencyRateUpdate(account_test_no_chart.TestAccountNoChartCommon):
         self.currency_checks.action_rebase_currency_company()
         self.assertEqual(
             self.move.line_ids[0].debit or self.move.line_ids[0].credit,
-            abs(self.move.line_ids[0].amount_currency)
+            abs(self.move.line_ids[0].currency_id._convert(
+                self.move.line_ids[0].amount_currency,
+                self.move.line_ids[0].company_currency_id,
+                self.move.line_ids[0].company_id, self.today
+            ))
         )
         self.assertEqual(
             self.move.line_ids[1].debit or self.move.line_ids[1].credit,
-            abs(self.move.line_ids[1].amount_currency)
+            abs(self.move.line_ids[1].currency_id._convert(
+                self.move.line_ids[1].amount_currency,
+                self.move.line_ids[1].company_currency_id,
+                self.move.line_ids[1].company_id, self.today
+            ))
         )

--- a/currency_rate_check/tests/test_currency_rate_update.py
+++ b/currency_rate_check/tests/test_currency_rate_update.py
@@ -1,0 +1,115 @@
+# Copyright 2021 VanMoof (<https://vanmoof.com>)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+from odoo import fields
+from odoo.addons.account.tests import account_test_no_chart
+from odoo.exceptions import MissingError
+
+
+class TestCurrencyRateUpdate(account_test_no_chart.TestAccountNoChartCommon):
+    def setUp(self):
+        super().setUp()
+        self.company_obj = self.env['res.company']
+        self.today = fields.Date.today()
+        self.eur_currency = self.env.ref('base.EUR')
+        self.jpy_currency = self.env.ref('base.JPY')
+        if self.env.user.company_id.currency_id == self.jpy_currency:
+            self.currency = self.eur_currency
+        else:
+            self.currency = self.jpy_currency
+        self.env['account.move.line'].with_context(
+            check_move_validity=False)
+        self.move = self.env['account.move'].create({
+            'name': 'move name',
+            'journal_id': self.sale_journal0.id,
+            'date': self.today,
+            'line_ids': [
+                (0, 0, {
+                    'name': 'debit',
+                    'account_id': self.account_receivable.id,
+                    'amount_currency': 1100,
+                    'currency_id': self.currency.id,
+                }),
+                (0, 0, {
+                    'name': 'credit',
+                    'account_id': self.account_payable.id,
+                    'amount_currency': -1100,
+                    'currency_id': self.currency.id,
+                }),
+            ],
+        })
+        self.rates = self.env['res.currency.rate'].create([
+            {'currency_id': self.eur_currency.id},
+            {'currency_id': self.jpy_currency.id},
+        ])
+        self.currency_check_obj = self.env['account.move.line.currency.check']
+        values = []
+        for line in self.move.line_ids:
+            values.append({
+                'line_id': line.id,
+                'rate_partner': self.rates[0].id,
+                'rate_company': self.rates[1].id,
+            })
+        self.currency_check_obj.create(values)
+        self.currency_checks = self.currency_check_obj.search([])
+        self.move.line_ids._onchange_amount_currency()
+
+    def test_update_rate_aml(self):
+        """Check that the amounts get updated when calling
+        action_rebase_currency_partner and action_rebase_currency_company after
+        intentionally mismatching (credit or debit) and amount_currency."""
+        date_from = date_to = self.today
+        line_limit = 2
+        ref = False
+        self.assertEqual(len(self.currency_checks), 2)
+        for line in self.move.line_ids:
+            if line.debit > 0:
+                line.debit += 50.0
+            elif line.credit > 0:
+                line.credit += 50.0
+        self.assertNotEqual(
+            self.move.line_ids[0].debit or self.move.line_ids[0].credit,
+            abs(self.move.line_ids[0].amount_currency)
+        )
+        self.assertNotEqual(
+            self.move.line_ids[1].debit or self.move.line_ids[1].credit,
+            abs(self.move.line_ids[1].amount_currency)
+        )
+        self.currency_checks.action_rebase_currency_partner()
+        # Check that the check lines are deleted after being rebased
+        with self.assertRaises(MissingError):
+            self.currency_checks.mapped('move_id')
+        self.assertEqual(
+            self.move.line_ids[0].debit or self.move.line_ids[0].credit,
+            abs(self.move.line_ids[0].amount_currency)
+        )
+        self.assertEqual(
+            self.move.line_ids[1].debit or self.move.line_ids[1].credit,
+            abs(self.move.line_ids[1].amount_currency)
+        )
+
+        for line in self.move.line_ids:
+            if line.debit > 0:
+                line.debit += 50.0
+            elif line.credit > 0:
+                line.credit += 50.0
+        self.assertNotEqual(
+            self.move.line_ids[0].debit or self.move.line_ids[0].credit,
+            abs(self.move.line_ids[0].amount_currency)
+        )
+        self.assertNotEqual(
+            self.move.line_ids[1].debit or self.move.line_ids[1].credit,
+            abs(self.move.line_ids[1].amount_currency)
+        )
+        self.currency_check_obj.action_update_check_lines(
+            date_from, date_to, line_limit, ref
+        )
+        self.currency_checks = self.currency_check_obj.search([])
+        self.currency_checks.action_rebase_currency_company()
+        self.assertEqual(
+            self.move.line_ids[0].debit or self.move.line_ids[0].credit,
+            abs(self.move.line_ids[0].amount_currency)
+        )
+        self.assertEqual(
+            self.move.line_ids[1].debit or self.move.line_ids[1].credit,
+            abs(self.move.line_ids[1].amount_currency)
+        )

--- a/currency_rate_check/views/account_move_line_currency_check.xml
+++ b/currency_rate_check/views/account_move_line_currency_check.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record model="ir.ui.view" id="view_currency_rate_form">
+        <field name="name">currency.check.form</field>
+        <field name="model">account.move.line.currency.check</field>
+        <!-- <field name="inherit_id" ref="base.view_currency_rate_form"/> -->
+        <field name="arch" type="xml">
+        <tree decoration-success="amount_currency==alt_amount_currency and (debit==abs(amount) or credit==abs(amount))">
+            <field name="line_id"/>
+            <field name="date"/>
+            <field name="rate_partner"/>
+            <field name="rate_company"/>
+            <field name="amount_currency" widget='monetary'/>
+            <field name="alt_amount_currency" widget='monetary'/>
+            <field name="currency_id"/>
+            <field name="amount" widget='monetary'/>
+            <field name="debit" widget='monetary'/>
+            <field name="credit" widget='monetary'/>
+            <field name="company_currency_id"/>
+        </tree>
+        </field>
+    </record>
+
+    <record id="res_currency_rate_provider_action_check_wizard" model="ir.actions.server">
+        <field name="name">Check Rates Wizard</field>
+        <field name="type">ir.actions.server</field>
+        <field name="model_id" ref="currency_rate_update.model_res_currency_rate_provider"/>
+        <field name="binding_model_id" ref="currency_rate_update.model_res_currency_rate_provider"/>
+        <field name="state">code</field>
+        <field name="code">
+if len(records) == 1:
+    action = {
+        'type': 'ir.actions.act_window',
+        'res_model': 'res.currency.rate.check.wizard',
+        'views': [[False, 'form']],
+        'target': 'new',
+        'context': {
+            'default_provider_ids': [(6, False, records.ids)],
+            'default_currency_ids': [(6, False, records.mapped('currency_ids').ids)],
+            'rate_check_name_get': True,
+        },
+    }
+else:
+    raise Warning("Please choose exactly one provider.")
+        </field>
+    </record>
+
+    <record id="account_move_line_currency_check_action_use_partner" model="ir.actions.server">
+        <field name="name">Copy Amount Company Currency to debit/credit</field>
+        <field name="type">ir.actions.server</field>
+        <field name="model_id" ref="currency_rate_check.model_account_move_line_currency_check"/>
+        <field name="binding_model_id" ref="currency_rate_check.model_account_move_line_currency_check"/>
+        <field name="state">code</field>
+        <field name="code">
+records.action_rebase_currency_partner()
+        </field>
+    </record>
+
+    <record id="account_move_line_currency_check_action_use_company" model="ir.actions.server">
+        <field name="name">Copy Amount Partner Currency to Amount Currency</field>
+        <field name="type">ir.actions.server</field>
+        <field name="model_id" ref="currency_rate_check.model_account_move_line_currency_check"/>
+        <field name="binding_model_id" ref="currency_rate_check.model_account_move_line_currency_check"/>
+        <field name="state">code</field>
+        <field name="code">
+records.action_rebase_currency_company()
+        </field>
+    </record>
+
+</odoo>

--- a/currency_rate_check/wizards/__init__.py
+++ b/currency_rate_check/wizards/__init__.py
@@ -1,0 +1,3 @@
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from . import res_currency_rate_check_wizard

--- a/currency_rate_check/wizards/res_currency_rate_check_wizard.py
+++ b/currency_rate_check/wizards/res_currency_rate_check_wizard.py
@@ -1,0 +1,90 @@
+# Copyright 2021 VanMoof (<https://vanmoof.com>)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models, api, _
+from odoo.exceptions import UserError
+
+
+class ResCurrencyRateCheckWizard(models.TransientModel):
+    _name = 'res.currency.rate.check.wizard'
+    _description = 'Currency Rate Check Wizard'
+
+    date_from = fields.Date(
+        string='Start Date',
+        required=True,
+        default=fields.Date.context_today,
+    )
+    date_to = fields.Date(
+        string='End Date',
+        required=True,
+        default=fields.Date.context_today,
+    )
+    provider_ids = fields.Many2many(
+        string='Providers',
+        comodel_name='res.currency.rate.provider',
+        column1='wizard_id',
+        column2='provider_id',
+    )
+    currency_ids = fields.Many2many(
+        string='Currencies',
+        comodel_name='res.currency',
+        column1='wizard_id',
+        column2='currency_id',
+    )
+    line_limit = fields.Integer(
+        string='Item Limit',
+        help="Only journal entries with at most this number of journal items will be "
+        "checked",
+        default=2
+    )
+    ref = fields.Char(string='Journal Entry Reference')
+
+    @api.multi
+    def action_check(self):
+        self.ensure_one()
+        missing_rates = []
+        for currency_id in self.currency_ids + self.env.user.company_id.currency_id:
+            self.env.cr.execute(
+                """
+                SELECT dates.i::date AS missing, rc.name
+                FROM generate_series(
+                    %(date_from)s, %(date_to)s, '1 day'::interval
+                ) dates(i)
+                LEFT JOIN res_currency AS rc ON id = %(currency_id)s
+                LEFT JOIN res_currency_rate AS rcr
+                ON rcr.name = dates.i
+                AND rcr.company_id = %(company_id)s
+                AND rcr.currency_id = %(currency_id)s
+                WHERE rcr IS NULL
+                ORDER BY dates.i ASC;
+                """, {
+                    'date_from': self.date_from,
+                    'date_to': self.date_to,
+                    'company_id': self.env.user.company_id.id,
+                    'currency_id': currency_id.id,
+                }
+            )
+            res = self.env.cr.fetchall()
+            missing_rates.extend(res)
+
+        if missing_rates:
+            message_data = '\n'.join(
+                [str((r[0].strftime('%Y-%m-%d'), r[1])) for r in missing_rates]
+            )
+            raise UserError(_(
+                "The following currency rates are missing:\n{}".format(message_data)
+                .replace('(', '').replace(')', '').replace('\'', '')
+            ))
+        res = self.env['account.move.line.currency.check'].action_update_check_lines(
+            self.date_from, self.date_to, self.line_limit, self.ref
+        )
+        if not res:
+            raise UserError(_("No incorrect currencies found!"))
+        return {
+            'type': 'ir.actions.act_window',
+            'name': _("Items with invalid rates"),
+            'view_type': 'form',
+            'view_mode': 'tree,form',
+            'res_model': 'account.move.line.currency.check',
+            'target': 'current',
+        }

--- a/currency_rate_check/wizards/res_currency_rate_check_wizard.xml
+++ b/currency_rate_check/wizards/res_currency_rate_check_wizard.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<odoo>
+
+    <record id="res_currency_rate_check_wizard_form" model="ir.ui.view">
+        <field name="name">res.currency.rate.check.wizard.form</field>
+        <field name="model">res.currency.rate.check.wizard</field>
+        <field name="arch" type="xml">
+            <form>
+                <div>
+                This wizard will show journal items which have mismatching amounts when considering currency exchange rates.<br/>
+                This wizard will use the rates that are currently in Odoo.<br/>
+                Only the current entity will be checked.<br/>
+                Warning: updating the amounts will override posted, reconciliation, and lock date checks.<br/>
+                The related reconciled journal items are not recomputed as they belong to entries with more than two items.<br/>
+                If a journal item does not have a directly related invoice a message of the change will not be written.<br/>
+                </div>
+                <group name="filter">
+                    <group name="date_range" colspan="2">
+                        <group>
+                            <field name="date_from"/>
+                            <field name="currency_ids" widget="many2many_tags" options="{'no_create_edit': True}"/>
+                        </group>
+                        <group>
+                            <field name="date_to"/>
+                            <field name="line_limit"/>
+                            <field name="ref"/>
+                        </group>
+                    </group>
+                </group>
+                <footer>
+                    <button name="action_check" string="Check" type="object" default_focus="1" class="oe_highlight"/>
+                    <button string="Cancel" class="oe_link" special="cancel" />
+                </footer>
+            </form>
+        </field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
This module allows users to check if amounts on multicurrency journal items don't match up according to the exchange rates in Odoo. If any are found, they are displayed in a list view. By selecting the journal items there and using a button in the actions menu, either the amount_currency or the debit/credit side can be recomputed. Currently this is limited to journal entries with two item, and related reconciled entries are not recomputed.