### PR TITLE
[12.0][FIX] currency_rate_update: Add noupdate=1 to cron record.

### DIFF
--- a/currency_rate_update/data/cron.xml
+++ b/currency_rate_update/data/cron.xml
@@ -3,7 +3,7 @@
     Copyright 2019 Brainbean Apps (https://brainbeanapps.com)
     License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 -->
-<odoo>
+<odoo noupdate="1">
 
     <record model="ir.cron" id="ir_cron_currency_rates_update_every_day">
         <field name="name">Currency Rates Update (OCA) daily</field>


### PR DESCRIPTION
FWP from 13.0: https://github.com/OCA/currency/pull/116

Add noupdate=1 to cron record.

Please @pedrobaeza and @chienandalu can you review it?

@Tecnativa TT32988