### PR TITLE
[14.0][FIX] currency_rate_update: Set the correct default value in the company_id field (avoid deprecated options)

### DIFF
--- a/currency_rate_update/models/res_currency_rate_provider.py
+++ b/currency_rate_update/models/res_currency_rate_provider.py
@@ -24,7 +24,7 @@ class ResCurrencyRateProvider(models.Model):
         string="Company",
         comodel_name="res.company",
         required=True,
-        default=lambda self: self._default_company_id(),
+        default=lambda self: self.env.company,
     )
     currency_name = fields.Char(
         string="Currency Name", related="company_id.currency_id.name"
@@ -251,10 +251,6 @@ class ResCurrencyRateProvider(models.Model):
             return relativedelta(weeks=self.interval_number)
         elif self.interval_type == "months":
             return relativedelta(months=self.interval_number)
-
-    @api.model
-    def _default_company_id(self):
-        return self.env["res.company"]._company_default_get()
 
     @api.model
     def _scheduled_update(self):


### PR DESCRIPTION
FWP from 13.0: https://github.com/OCA/currency/pull/121

Set the correct default value in the `company_id` field (avoid deprecated options).

This change will need to be applied to v14 as well.

Please @pedrobaeza and @joao-p-marques can you review it?

@Tecnativa TT25624