### PR TITLE
[14.0][FIX] currency_rate_update: Prevent last_successful_run update if all records not create

### DIFF
--- a/currency_rate_update/models/res_currency_rate_provider.py
+++ b/currency_rate_update/models/res_currency_rate_provider.py
@@ -1,6 +1,7 @@
 # Copyright 2009-2016 Camptocamp
 # Copyright 2010 Akretion
 # Copyright 2019-2020 Brainbean Apps (https://brainbeanapps.com)
+# Copyright 2021 Tecnativa - Víctor Martínez
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
 import logging
@@ -116,6 +117,9 @@ class ResCurrencyRateProvider(models.Model):
                 [("name", "in", provider._get_supported_currencies())]
             )
 
+    def _get_close_time(self):
+        return False
+
     def _update(self, date_from, date_to, newest_only=False):
         Currency = self.env["res.currency"]
         CurrencyRate = self.env["res.currency.rate"]
@@ -127,7 +131,9 @@ class ResCurrencyRateProvider(models.Model):
                     provider.currency_ids.mapped("name"),
                     date_from,
                     date_to,
-                ).items()
+                )
+                if data:
+                    data = data.items()
             except BaseException as e:
                 _logger.warning(
                     'Currency Rate Provider "%s" failed to obtain data since'
@@ -275,7 +281,14 @@ class ResCurrencyRateProvider(models.Model):
                     else (provider.next_run - provider._get_next_run_period())
                 )
                 date_to = provider.next_run
-                provider._update(date_from, date_to, newest_only=True)
+                if (date_to != fields.Date.today()) or (
+                    date_to == fields.Date.today()
+                    and (
+                        not provider._get_close_time()
+                        or datetime.now().hour >= provider._get_close_time()
+                    )
+                ):
+                    provider._update(date_from, date_to, newest_only=True)
 
         _logger.info("Scheduled currency rates update complete.")
 

--- a/currency_rate_update/models/res_currency_rate_provider_ECB.py
+++ b/currency_rate_update/models/res_currency_rate_provider_ECB.py
@@ -19,6 +19,11 @@ class ResCurrencyRateProviderECB(models.Model):
         ondelete={"ECB": "set default"},
     )
 
+    def _get_close_time(self):
+        if self.service == "ECB":
+            return 17
+        return super()._get_close_time()
+
     def _get_supported_currencies(self):
         self.ensure_one()
         if self.service != "ECB":


### PR DESCRIPTION
FWP from 13.0: https://github.com/OCA/currency/pull/117

Prevent last_successful_run update if all records not create to every currencies and dates needed.

**Example**: BCE update rate in 14:00+01:00 and if we define ir_cron to 02:00 hour, read all the info but not exists records from some currencies from today but updated last_successful_run field and NOT save any records to some currencies and dates. Tomorrow the same problem and without any record save about currency rate.

**Solution**: Add method `_get_close_date` that allow define close hour. If defined, only when hour is greater is executed update for this provider.

**Issue related**: https://github.com/OCA/currency/issues/84

Please, @chienandalu and @pedrobaeza  can you review it?

@Tecnativa TT25624