### PR TITLE
[14.0][FIX] currency_rate_inverted: avoid multicompany error (forward port)

### DIFF
--- a/currency_rate_inverted/models/res_currency.py
+++ b/currency_rate_inverted/models/res_currency.py
@@ -1,3 +1,4 @@
+# Copyright 2021 Sergej Ruzki. ReSuSolutions.
 # Copyright 2021 ForgeFlow, S.L.
 # Copyright 2015 Techrifiv Solutions Pte Ltd
 # Copyright 2015 Statecraft Systems Pte Ltd
@@ -17,6 +18,9 @@ class ResCurrency(models.Model):
     @api.model
     def _get_conversion_rate(self, from_currency, to_currency, company, date):
         rate = super()._get_conversion_rate(from_currency, to_currency, company, date)
+
+        from_currency = from_currency.with_company(company)
+        to_currency = to_currency.with_company(company)
 
         if not from_currency.rate_inverted and not to_currency.rate_inverted:
             return rate

--- a/currency_rate_inverted/readme/CONTRIBUTORS.rst
+++ b/currency_rate_inverted/readme/CONTRIBUTORS.rst
@@ -7,3 +7,4 @@
   * Alexey Pelykh <alexey.pelykh@corphub.eu>
 
 * Pimolnat Suntian <pimolnats@ecosoft.co.th>
+* SkiBY (Sergej Ruzki <sergei.ruzki@gmail.com>)


### PR DESCRIPTION
Forward port of https://github.com/OCA/currency/pull/107.