### PR TITLE
[13.0][IMP] currency_rate_update: Do not call the _schedule_next_run() method if there is no data.

### DIFF
--- a/currency_rate_update/models/res_currency_rate_provider.py
+++ b/currency_rate_update/models/res_currency_rate_provider.py
@@ -112,9 +112,6 @@ class ResCurrencyRateProvider(models.Model):
                 [("name", "in", provider._get_supported_currencies())]
             )
 
-    def _get_close_time(self):
-        return False
-
     def _update(self, date_from, date_to, newest_only=False):
         Currency = self.env["res.currency"]
         CurrencyRate = self.env["res.currency.rate"]
@@ -188,14 +185,20 @@ class ResCurrencyRateProvider(models.Model):
                         )
 
             if is_scheduled:
+                provider._schedule_last_successful_run()
                 provider._schedule_next_run()
+
+    def _schedule_last_successful_run(self):
+        self.last_successful_run = self.next_run
 
     def _schedule_next_run(self):
         self.ensure_one()
-        self.last_successful_run = self.next_run
-        self.next_run = (
-            datetime.combine(self.next_run, time.min) + self._get_next_run_period()
-        ).date()
+        self.next_run = min(
+            (
+                datetime.combine(self.next_run, time.min) + self._get_next_run_period()
+            ).date(),
+            fields.Date.today(),
+        )
 
     def _process_rate(self, currency, rate):
         self.ensure_one()
@@ -266,14 +269,7 @@ class ResCurrencyRateProvider(models.Model):
                     else (provider.next_run - provider._get_next_run_period())
                 )
                 date_to = provider.next_run
-                if (date_to != fields.Date.today()) or (
-                    date_to == fields.Date.today()
-                    and (
-                        not provider._get_close_time()
-                        or datetime.now().hour >= provider._get_close_time()
-                    )
-                ):
-                    provider._update(date_from, date_to, newest_only=True)
+                provider._update(date_from, date_to, newest_only=True)
 
         _logger.info("Scheduled currency rates update complete.")
 

--- a/currency_rate_update/models/res_currency_rate_provider_ECB.py
+++ b/currency_rate_update/models/res_currency_rate_provider_ECB.py
@@ -16,11 +16,6 @@ class ResCurrencyRateProviderECB(models.Model):
 
     service = fields.Selection(selection_add=[("ECB", "European Central Bank")])
 
-    def _get_close_time(self):
-        if self.service == "ECB":
-            return 19  # 18:30
-        return super()._get_close_time()
-
     def _get_supported_currencies(self):
         self.ensure_one()
         if self.service != "ECB":

--- a/currency_rate_update/tests/test_currency_rate_update.py
+++ b/currency_rate_update/tests/test_currency_rate_update.py
@@ -157,7 +157,7 @@ class TestCurrencyRateUpdate(AccountingSavepointCase):
         self.ecb_provider._scheduled_update()
         self.ecb_provider._scheduled_update()
 
-        self.assertEqual(self.ecb_provider.last_successful_run, date(2019, 7, 7))
+        self.assertEqual(self.ecb_provider.last_successful_run, date(2019, 7, 5))
         self.assertEqual(self.ecb_provider.next_run, date(2019, 7, 8))
 
     def test_foreign_base_currency(self):


### PR DESCRIPTION
Do not call the _schedule_next_run() method if there is no data.

This change allows you to make as many requests as you want on a daily basis without updating the `last_successful_run` and `next_run` fields.

Please @pedrobaeza can you review it?

@Tecnativa TT40688