### PR TITLE
[14.0][IMP] currency_rate_update: Do not call the _schedule_next_run() method if there is no data.

### DIFF
--- a/currency_rate_update/models/res_currency_rate_provider_ECB.py
+++ b/currency_rate_update/models/res_currency_rate_provider_ECB.py
@@ -19,32 +19,6 @@ class ResCurrencyRateProviderECB(models.Model):
         ondelete={"ECB": "set default"},
     )
 
-    def _get_close_time(self):
-        """According to official page "Euro foreign exchange reference rates"
-        on the ECB Website, today's rate data will only be available
-        from 16:00 CET.
-        https://www.ecb.europa.eu/stats/policy_and_exchange_rates/
-        euro_reference_exchange_rates/html/index.en.html
-
-        It is necessary to define a blocking time to avoid the following use case:
-        - Cron record call webservice today BEFORE time x.
-        - The webservice response will not give an error but it will not return data
-        for today.
-        - The value of last_successful_run will be updated with today's date.
-        - The value of next_run will be updated to tomorrow.
-
-        You would never get the value for today and tomorrow the same thing would happen.
-
-        CET Time is UTC+2 in summer and UTC+1 in winter:
-        (https://en.wikipedia.org/wiki/Central_European_Time).
-        Block time must be set to UTC+0
-        Set time to 15, which is UTC hour that corresponds to
-        16:00 CET in winter and 17:00 CET in summer => ok with the ECB publication time
-        """
-        if self.service == "ECB":
-            return 15
-        return super()._get_close_time()
-
     def _get_supported_currencies(self):
         self.ensure_one()
         if self.service != "ECB":

--- a/currency_rate_update/tests/test_currency_rate_update.py
+++ b/currency_rate_update/tests/test_currency_rate_update.py
@@ -157,7 +157,7 @@ class TestCurrencyRateUpdate(AccountTestInvoicingCommon):
         self.ecb_provider._scheduled_update()
         self.ecb_provider._scheduled_update()
 
-        self.assertEqual(self.ecb_provider.last_successful_run, date(2019, 7, 7))
+        self.assertEqual(self.ecb_provider.last_successful_run, date(2019, 7, 5))
         self.assertEqual(self.ecb_provider.next_run, date(2019, 7, 8))
 
     def test_foreign_base_currency(self):


### PR DESCRIPTION
FWP from 13.0: https://github.com/OCA/currency/pull/147

Do not call the _schedule_next_run() method if there is no data.

This change allows you to make as many requests as you want on a daily basis without updating the `last_successful_run` and `next_run` fields.

Please @pedrobaeza can you review it?

@Tecnativa TT40688