### PR TITLE
[16.0][FIX] currency_rate_update

### DIFF
--- a/currency_rate_update/models/res_currency_rate_provider.py
+++ b/currency_rate_update/models/res_currency_rate_provider.py
@@ -260,7 +260,7 @@ class ResCurrencyRateProvider(models.Model):
     def _scheduled_update(self):
         _logger.info("Scheduled currency rates update...")
 
-        today = fields.Date.today()
+        today = fields.Date.context_today(self)
         providers = self.search(
             [
                 ("company_id.currency_rates_autoupdate", "=", True),


### PR DESCRIPTION
Use context_today() instead of today() to search provider records against next_run.

Before this commit, scheduled updates before 09:00 a.m. would have trouble identifying the target providers for installations in Japan, for example.
**Note**: Japan timezone is GMT+9.