### PR TITLE
[16.0][IMP] currency_rate_update: Do not call the _schedule_next_run() method if there is no data.

### DIFF
--- a/currency_rate_update/models/res_currency_rate_provider.py
+++ b/currency_rate_update/models/res_currency_rate_provider.py
@@ -115,9 +115,6 @@ class ResCurrencyRateProvider(models.Model):
                 [("name", "in", provider._get_supported_currencies())]
             )
 
-    def _get_close_time(self):
-        return False
-
     def _update(self, date_from, date_to, newest_only=False):
         Currency = self.env["res.currency"]
         CurrencyRate = self.env["res.currency.rate"]
@@ -159,8 +156,7 @@ class ResCurrencyRateProvider(models.Model):
                 continue
 
             if not data:
-                if is_scheduled:
-                    provider._schedule_next_run()
+                # Try again if there is no data yet
                 continue
             if newest_only:
                 data = [max(data, key=lambda x: fields.Date.from_string(x[0]))]
@@ -201,11 +197,14 @@ class ResCurrencyRateProvider(models.Model):
                         )
 
             if is_scheduled:
+                provider._schedule_last_successful_run()
                 provider._schedule_next_run()
+
+    def _schedule_last_successful_run(self):
+        self.last_successful_run = self.next_run
 
     def _schedule_next_run(self):
         self.ensure_one()
-        self.last_successful_run = self.next_run
         self.next_run = (
             datetime.combine(self.next_run, time.min) + self._get_next_run_period()
         ).date()
@@ -280,28 +279,8 @@ class ResCurrencyRateProvider(models.Model):
                     else (provider.next_run - provider._get_next_run_period())
                 )
                 date_to = provider.next_run
-                provider_utc_close_hour = provider._get_close_time()
-                current_utc_hour = datetime.now().hour
-                _logger.debug(
-                    "Provider %s date_to=%s today=%s provider close hour %s UTC, "
-                    "current hour %s UTC",
-                    provider.name,
-                    date_to,
-                    today,
-                    provider_utc_close_hour,
-                    current_utc_hour,
-                )
-                if (date_to != today) or (
-                    date_to == today
-                    and (
-                        not provider_utc_close_hour
-                        or current_utc_hour >= provider_utc_close_hour
-                    )
-                ):
-                    provider._update(date_from, date_to, newest_only=True)
-                    _logger.info("Currency rates updated from %s", provider.name)
-                else:
-                    _logger.info("Skip currency rate update from %s", provider.name)
+                provider._update(date_from, date_to, newest_only=True)
+
         _logger.info("Scheduled currency rates update complete.")
 
     def _get_supported_currencies(self):

--- a/currency_rate_update/models/res_currency_rate_provider_ECB.py
+++ b/currency_rate_update/models/res_currency_rate_provider_ECB.py
@@ -19,30 +19,6 @@ class ResCurrencyRateProviderECB(models.Model):
         ondelete={"ECB": "set default"},
     )
 
-    def _get_close_time(self):
-        """According to official page "Euro foreign exchange reference rates"
-        on the ECB Website, today's rate data are available from 16:00 CET.
-        https://www.ecb.europa.eu/stats/policy_and_exchange_rates/
-        euro_reference_exchange_rates/html/index.en.html
-        It is necessary to define a blocking time to avoid the following use case:
-        - Cron record call webservice today BEFORE time x.
-        - The webservice response will not give an error but it will not return data
-        for today.
-        - The value of last_successful_run will be updated with today's date.
-        - The value of next_run will be updated to tomorrow.
-
-        You would never get the value for today and tomorrow the same thing would happen.
-
-        CET Time is UTC+2 in summer and UTC+1 in winter:
-        (https://en.wikipedia.org/wiki/Central_European_Time).
-        Block time must be set to UTC+0
-        Set time to 15, which is UTC hour that corresponds to
-        16:00 CET in winter and 17:00 CET in summer => ok with the ECB publication time
-        """
-        if self.service == "ECB":
-            return 15
-        return super()._get_close_time()
-
     def _get_supported_currencies(self):
         self.ensure_one()
         if self.service != "ECB":

--- a/currency_rate_update/tests/test_currency_rate_update.py
+++ b/currency_rate_update/tests/test_currency_rate_update.py
@@ -157,8 +157,8 @@ class TestCurrencyRateUpdate(AccountTestInvoicingCommon):
         self.ecb_provider._scheduled_update()
         self.ecb_provider._scheduled_update()
 
-        self.assertEqual(self.ecb_provider.last_successful_run, date(2019, 7, 7))
-        self.assertEqual(self.ecb_provider.next_run, date(2019, 7, 8))
+        self.assertEqual(self.ecb_provider.last_successful_run, date(2019, 7, 5))
+        self.assertEqual(self.ecb_provider.next_run, date(2019, 7, 6))
 
     def test_foreign_base_currency(self):
         self.company.currency_id = self.chf_currency


### PR DESCRIPTION
FWP from 15.0: https://github.com/OCA/currency/pull/150

Do not call the _schedule_next_run() method if there is no data.

This change allows you to make as many requests as you want on a daily basis without updating the `last_successful_run` and `next_run` fields.

Please @pedrobaeza can you review it?

@Tecnativa TT40688