### PR TITLE
[15.0][FIX] currency_rate_update: Fix next_run (Avoid always set with current date)

### DIFF
--- a/currency_rate_update/models/res_currency_rate_provider.py
+++ b/currency_rate_update/models/res_currency_rate_provider.py
@@ -156,8 +156,7 @@ class ResCurrencyRateProvider(models.Model):
                 continue
 
             if not data:
-                if is_scheduled:
-                    provider._schedule_next_run()
+                # Try again if there is no data yet
                 continue
             if newest_only:
                 data = [max(data, key=lambda x: fields.Date.from_string(x[0]))]
@@ -206,12 +205,9 @@ class ResCurrencyRateProvider(models.Model):
 
     def _schedule_next_run(self):
         self.ensure_one()
-        self.next_run = min(
-            (
-                datetime.combine(self.next_run, time.min) + self._get_next_run_period()
-            ).date(),
-            fields.Date.today(),
-        )
+        self.next_run = (
+            datetime.combine(self.next_run, time.min) + self._get_next_run_period()
+        ).date()
 
     def _process_rate(self, currency, rate):
         self.ensure_one()

--- a/currency_rate_update/tests/test_currency_rate_update.py
+++ b/currency_rate_update/tests/test_currency_rate_update.py
@@ -158,7 +158,7 @@ class TestCurrencyRateUpdate(AccountTestInvoicingCommon):
         self.ecb_provider._scheduled_update()
 
         self.assertEqual(self.ecb_provider.last_successful_run, date(2019, 7, 5))
-        self.assertEqual(self.ecb_provider.next_run, date(2019, 7, 8))
+        self.assertEqual(self.ecb_provider.next_run, date(2019, 7, 6))
 
     def test_foreign_base_currency(self):
         self.company.currency_id = self.chf_currency


### PR DESCRIPTION
FWP from 14.0: https://github.com/OCA/currency/pull/155

Related to https://github.com/OCA/currency/pull/153#discussion_r1055242054

Fix next_run (Avoid always set with current date)

Please @pedrobaeza could you review it?

This change is required in: 13.0, 14.0 and 15.0.

@Tecnativa TT40688