### PR TITLE
[16.0][IMP] currency_rate_update

### DIFF
--- a/currency_rate_update/models/res_currency_rate_provider.py
+++ b/currency_rate_update/models/res_currency_rate_provider.py
@@ -65,6 +65,7 @@ class ResCurrencyRateProvider(models.Model):
     next_run = fields.Date(
         string="Next scheduled update", default=fields.Date.today, required=True
     )
+    daily = fields.Boolean(compute="_compute_daily", store=True)
 
     _sql_constraints = [
         (
@@ -115,6 +116,13 @@ class ResCurrencyRateProvider(models.Model):
                 [("name", "in", provider._get_supported_currencies())]
             )
 
+    @api.depends("interval_type", "interval_number")
+    def _compute_daily(self):
+        for provider in self:
+            provider.daily = False
+            if provider.interval_type == "days" and provider.interval_number == 1:
+                provider.daily = True
+
     def _update(self, date_from, date_to, newest_only=False):
         Currency = self.env["res.currency"]
         CurrencyRate = self.env["res.currency.rate"]
@@ -161,8 +169,11 @@ class ResCurrencyRateProvider(models.Model):
             if newest_only:
                 data = [max(data, key=lambda x: fields.Date.from_string(x[0]))]
 
+            newest_date = False
             for content_date, rates in data:
                 timestamp = fields.Date.from_string(content_date)
+                if not newest_date or timestamp > newest_date:
+                    newest_date = timestamp
                 for currency_name, rate in rates.items():
                     if currency_name == provider.company_id.currency_id.name:
                         continue
@@ -197,16 +208,17 @@ class ResCurrencyRateProvider(models.Model):
                         )
 
             if is_scheduled:
-                provider._schedule_last_successful_run()
-                provider._schedule_next_run()
+                provider._schedule_last_successful_run(newest_date)
+                provider._schedule_next_run(newest_date)
 
-    def _schedule_last_successful_run(self):
-        self.last_successful_run = self.next_run
+    def _schedule_last_successful_run(self, newest_date):
+        self.last_successful_run = newest_date
 
-    def _schedule_next_run(self):
+    def _schedule_next_run(self, newest_date):
+        # next_run is not used when daily is true, but we are updating the value anyway.
         self.ensure_one()
         self.next_run = (
-            datetime.combine(self.next_run, time.min) + self._get_next_run_period()
+            datetime.combine(newest_date, time.min) + self._get_next_run_period()
         ).date()
 
     def _process_rate(self, currency, rate):
@@ -260,11 +272,14 @@ class ResCurrencyRateProvider(models.Model):
         _logger.info("Scheduled currency rates update...")
 
         today = fields.Date.context_today(self)
+        # When daily is true, the provider should always be picked for scheduled update.
         providers = self.search(
             [
                 ("company_id.currency_rates_autoupdate", "=", True),
                 ("active", "=", True),
+                "|",
                 ("next_run", "<=", today),
+                ("daily", "=", True),
             ]
         )
         if providers:
@@ -278,9 +293,13 @@ class ResCurrencyRateProvider(models.Model):
                     if provider.last_successful_run
                     else (provider.next_run - provider._get_next_run_period())
                 )
+                newest_only = True
                 date_to = provider.next_run
-                provider._update(date_from, date_to, newest_only=True)
-
+                # Fetch next_run to today data
+                if provider.daily:
+                    newest_only = False
+                    date_to = today
+                provider._update(date_from, date_to, newest_only=newest_only)
         _logger.info("Scheduled currency rates update complete.")
 
     def _get_supported_currencies(self):

--- a/currency_rate_update/readme/CONTRIBUTORS.rst
+++ b/currency_rate_update/readme/CONTRIBUTORS.rst
@@ -22,3 +22,7 @@
 * `CorporateHub <https://corporatehub.eu/>`__
 
   * Alexey Pelykh <alexey.pelykh@corphub.eu>
+
+* `Quartile Limited <https://www.quartile.co/>`__:
+
+  * Tatsuki Kanda <kanda@quartile.co>

--- a/currency_rate_update/views/res_currency_rate_provider.xml
+++ b/currency_rate_update/views/res_currency_rate_provider.xml
@@ -29,7 +29,8 @@
                 <field name="update_schedule" />
                 <field name="available_currency_ids" invisible="1" />
                 <field name="currency_ids" widget="many2many_tags" />
-                <field name="next_run" />
+                <field name="daily" invisible="1" />
+                <field name="next_run" attrs="{'invisible': [('daily', '=', True)]}" />
             </tree>
         </field>
     </record>
@@ -79,7 +80,11 @@
                             <field name="last_successful_run" />
                         </group>
                         <group>
-                            <field name="next_run" />
+                            <field name="daily" invisible="1" />
+                            <field
+                                name="next_run"
+                                attrs="{'invisible': [('daily', '=', True)]}"
+                            />
                         </group>
                         <group>
                             <field name="available_currency_ids" invisible="1" />


### PR DESCRIPTION
Current behavior:
https://github.com/OCA/currency/pull/153 
With this update, If there are days with no data then the rate updates will get stuck.  Get the data, otherwise scheduled_date will not be updated to avoid lost data.
Therefore, you cannot use a provider that does not update data on weekends.

This comment shows that the weekend update with no data was considered in V13.
https://github.com/OCA/currency/pull/147#issuecomment-1346322636

But when there is no data, the method provider._schedule_next_run() has been erased in V16 and backport this update.
https://github.com/OCA/currency/pull/153#discussion_r1055358952

I created a Integer field in provider to be able to use providers with no data on weekends with this update.
Integer field allows you to set the number of tries scheduled action.