### PR TITLE
[14.0][FIX] currency_rate_update

### DIFF
--- a/currency_rate_update/models/res_currency_rate_provider.py
+++ b/currency_rate_update/models/res_currency_rate_provider.py
@@ -67,6 +67,7 @@ class ResCurrencyRateProvider(models.Model):
     next_run = fields.Date(
         string="Next scheduled update", default=fields.Date.today, required=True
     )
+    daily = fields.Boolean(compute="_compute_daily", store=True)
 
     _sql_constraints = [
         (
@@ -117,6 +118,13 @@ class ResCurrencyRateProvider(models.Model):
                 [("name", "in", provider._get_supported_currencies())]
             )
 
+    @api.depends("interval_type", "interval_number")
+    def _compute_daily(self):
+        for provider in self:
+            provider.daily = False
+            if provider.interval_type == "days" and provider.interval_number == 1:
+                provider.daily = True
+
     def _update(self, date_from, date_to, newest_only=False):
         Currency = self.env["res.currency"]
         CurrencyRate = self.env["res.currency.rate"]
@@ -163,8 +171,11 @@ class ResCurrencyRateProvider(models.Model):
             if newest_only:
                 data = [max(data, key=lambda x: fields.Date.from_string(x[0]))]
 
+            newest_date = False
             for content_date, rates in data:
                 timestamp = fields.Date.from_string(content_date)
+                if not newest_date or timestamp > newest_date:
+                    newest_date = timestamp
                 for currency_name, rate in rates.items():
                     if currency_name == provider.company_id.currency_id.name:
                         continue
@@ -199,16 +210,17 @@ class ResCurrencyRateProvider(models.Model):
                         )
 
             if is_scheduled:
-                provider._schedule_last_successful_run()
-                provider._schedule_next_run()
+                provider._schedule_last_successful_run(newest_date)
+                provider._schedule_next_run(newest_date)
 
-    def _schedule_last_successful_run(self):
-        self.last_successful_run = self.next_run
+    def _schedule_last_successful_run(self, newest_date):
+        self.last_successful_run = newest_date
 
-    def _schedule_next_run(self):
+    def _schedule_next_run(self, newest_date):
+        # next_run is not used when daily is true, but we are updating the value anyway.
         self.ensure_one()
         self.next_run = (
-            datetime.combine(self.next_run, time.min) + self._get_next_run_period()
+            datetime.combine(newest_date, time.min) + self._get_next_run_period()
         ).date()
 
     def _process_rate(self, currency, rate):
@@ -262,11 +274,14 @@ class ResCurrencyRateProvider(models.Model):
         _logger.info("Scheduled currency rates update...")
 
         today = fields.Date.context_today(self)
+        # When daily is true, the provider should always be picked for scheduled update.
         providers = self.search(
             [
                 ("company_id.currency_rates_autoupdate", "=", True),
                 ("active", "=", True),
+                "|",
                 ("next_run", "<=", today),
+                ("daily", "=", True),
             ]
         )
         if providers:
@@ -280,6 +295,7 @@ class ResCurrencyRateProvider(models.Model):
                     if provider.last_successful_run
                     else (provider.next_run - provider._get_next_run_period())
                 )
+                newest_only = True
                 date_to = provider.next_run
                 current_utc_hour = datetime.now().hour
                 _logger.debug(
@@ -289,9 +305,12 @@ class ResCurrencyRateProvider(models.Model):
                     today,
                     current_utc_hour,
                 )
-                provider._update(date_from, date_to, newest_only=True)
+                # Fetch next_run to today data
+                if provider.daily:
+                    newest_only = False
+                    date_to = today
+                provider._update(date_from, date_to, newest_only=newest_only)
                 _logger.info("Currency rates updated from %s", provider.name)
-
         _logger.info("Scheduled currency rates update complete.")
 
     def _get_supported_currencies(self):

--- a/currency_rate_update/readme/CONTRIBUTORS.rst
+++ b/currency_rate_update/readme/CONTRIBUTORS.rst
@@ -22,3 +22,7 @@
 * `CorporateHub <https://corporatehub.eu/>`__
 
   * Alexey Pelykh <alexey.pelykh@corphub.eu>
+
+* `Quartile Limited <https://www.quartile.co/>`__:
+
+  * Tatsuki Kanda <kanda@quartile.co>

--- a/currency_rate_update/tests/test_currency_rate_update.py
+++ b/currency_rate_update/tests/test_currency_rate_update.py
@@ -6,6 +6,7 @@ from datetime import date
 from unittest import mock
 
 from dateutil.relativedelta import relativedelta
+from freezegun import freeze_time
 
 from odoo import fields
 from odoo.tests import tagged
@@ -111,13 +112,13 @@ class TestCurrencyRateUpdate(AccountTestInvoicingCommon):
 
     def test_update_ECB_sequence(self):
         self.ecb_provider.interval_type = "days"
-        self.ecb_provider.interval_number = 1
+        self.ecb_provider.interval_number = 2
         self.ecb_provider.last_successful_run = None
         self.ecb_provider.next_run = date(2019, 4, 1)
 
         self.ecb_provider._scheduled_update()
         self.assertEqual(self.ecb_provider.last_successful_run, date(2019, 4, 1))
-        self.assertEqual(self.ecb_provider.next_run, date(2019, 4, 2))
+        self.assertEqual(self.ecb_provider.next_run, date(2019, 4, 3))
         rates = self.CurrencyRate.search(
             [
                 ("company_id", "=", self.company.id),
@@ -127,8 +128,8 @@ class TestCurrencyRateUpdate(AccountTestInvoicingCommon):
         self.assertEqual(len(rates), 1)
 
         self.ecb_provider._scheduled_update()
-        self.assertEqual(self.ecb_provider.last_successful_run, date(2019, 4, 2))
-        self.assertEqual(self.ecb_provider.next_run, date(2019, 4, 3))
+        self.assertEqual(self.ecb_provider.last_successful_run, date(2019, 4, 3))
+        self.assertEqual(self.ecb_provider.next_run, date(2019, 4, 5))
         rates = self.CurrencyRate.search(
             [
                 ("company_id", "=", self.company.id),
@@ -141,7 +142,7 @@ class TestCurrencyRateUpdate(AccountTestInvoicingCommon):
 
     def test_update_ECB_weekend(self):
         self.ecb_provider.interval_type = "days"
-        self.ecb_provider.interval_number = 1
+        self.ecb_provider.interval_number = 2
         self.ecb_provider.last_successful_run = None
         self.ecb_provider.next_run = date(2019, 7, 1)
 
@@ -152,13 +153,26 @@ class TestCurrencyRateUpdate(AccountTestInvoicingCommon):
         self.ecb_provider._scheduled_update()
 
         self.assertEqual(self.ecb_provider.last_successful_run, date(2019, 7, 5))
-        self.assertEqual(self.ecb_provider.next_run, date(2019, 7, 6))
+        self.assertEqual(self.ecb_provider.next_run, date(2019, 7, 7))
 
         self.ecb_provider._scheduled_update()
         self.ecb_provider._scheduled_update()
 
         self.assertEqual(self.ecb_provider.last_successful_run, date(2019, 7, 5))
-        self.assertEqual(self.ecb_provider.next_run, date(2019, 7, 6))
+        self.assertEqual(self.ecb_provider.next_run, date(2019, 7, 7))
+
+    @freeze_time("2022-04-19 22:00")
+    def test_update_ECB_with_daily(self):
+        self.ecb_provider.interval_type = "days"
+        self.ecb_provider.interval_number = 1
+        # Setting last_successful_run a date more than 90 days prior to the
+        # freeze_time date, to make sure that the rates are taken from
+        # '/eurofxref-hist.xml'.
+        self.ecb_provider.last_successful_run = date(2021, 4, 19)
+
+        self.ecb_provider._scheduled_update()
+
+        self.assertEqual(self.ecb_provider.last_successful_run, date(2022, 4, 19))
 
     def test_foreign_base_currency(self):
         self.company.currency_id = self.chf_currency

--- a/currency_rate_update/views/res_currency_rate_provider.xml
+++ b/currency_rate_update/views/res_currency_rate_provider.xml
@@ -29,7 +29,8 @@
                 <field name="update_schedule" />
                 <field name="available_currency_ids" invisible="1" />
                 <field name="currency_ids" widget="many2many_tags" />
-                <field name="next_run" />
+                <field name="daily" invisible="1" />
+                <field name="next_run" attrs="{'invisible': [('daily', '=', True)]}" />
             </tree>
         </field>
     </record>
@@ -79,7 +80,11 @@
                             <field name="last_successful_run" />
                         </group>
                         <group>
-                            <field name="next_run" />
+                            <field name="daily" invisible="1" />
+                            <field
+                                name="next_run"
+                                attrs="{'invisible': [('daily', '=', True)]}"
+                            />
                         </group>
                         <group>
                             <field name="available_currency_ids" invisible="1" />


### PR DESCRIPTION
FWP from 13.0: https://github.com/OCA/currency/pull/162

Before this commit, there was a problem of next_run getting stuck when there is no rate data received for the day (e.g. weekend).

This commit fixes the issue by totally ignoring next_run for daily update settings, meaning that the provider always fetches the latast rates from last_successful_run to today.

Please @pedrobaeza can you review it?

@Tecnativa TT40688