### PR TITLE
[16.0] currency_rate_update: fix bad strings

### DIFF
--- a/currency_rate_update/models/res_company.py
+++ b/currency_rate_update/models/res_company.py
@@ -11,5 +11,5 @@ class ResCompany(models.Model):
     currency_rates_autoupdate = fields.Boolean(
         string="Automatic Currency Rates (OCA)",
         default=True,
-        help="Enable regular automatic currency rates updates",
+        help="Enable automatic currency rates updates in this company.",
     )

--- a/currency_rate_update/models/res_config_settings.py
+++ b/currency_rate_update/models/res_config_settings.py
@@ -9,8 +9,6 @@ class ResConfigSettings(models.TransientModel):
     _inherit = "res.config.settings"
 
     currency_rates_autoupdate = fields.Boolean(
-        string="Automatic Currency Rates (OCA)",
         related="company_id.currency_rates_autoupdate",
         readonly=False,
-        help="Enable regular automatic currency rates updates",
     )

--- a/currency_rate_update/models/res_currency_rate_provider.py
+++ b/currency_rate_update/models/res_currency_rate_provider.py
@@ -32,7 +32,7 @@ class ResCurrencyRateProvider(models.Model):
     )
     active = fields.Boolean(default=True)
     service = fields.Selection(
-        string="Source Service",
+        string="Provider",
         selection=[("none", "None")],
         default="none",
         required=True,
@@ -52,18 +52,18 @@ class ResCurrencyRateProvider(models.Model):
     )
     name = fields.Char(compute="_compute_name", store=True)
     interval_type = fields.Selection(
-        string="Units of scheduled update interval",
+        string="Scheduled Update Interval Unit",
         selection=[("days", "Day(s)"), ("weeks", "Week(s)"), ("months", "Month(s)")],
         default="days",
         required=True,
     )
     interval_number = fields.Integer(
-        string="Scheduled update interval", default=1, required=True
+        string="Scheduled Update Interval", default=1, required=True
     )
     update_schedule = fields.Char(compute="_compute_update_schedule")
-    last_successful_run = fields.Date(string="Last successful update")
+    last_successful_run = fields.Date(string="Last Successful Update")
     next_run = fields.Date(
-        string="Next scheduled update", default=fields.Date.today, required=True
+        string="Next Scheduled Update", default=fields.Date.today, required=True
     )
     daily = fields.Boolean(compute="_compute_daily", store=True)
 
@@ -71,12 +71,12 @@ class ResCurrencyRateProvider(models.Model):
         (
             "service_company_id_uniq",
             "UNIQUE(service, company_id)",
-            "Service can only be used in one provider per company!",
+            "This provider has already been setup in this company.",
         ),
         (
             "valid_interval_number",
             "CHECK(interval_number > 0)",
-            "Scheduled update interval must be greater than zero!",
+            "Scheduled update interval must be strictly positive.",
         ),
     ]
 
@@ -236,7 +236,7 @@ class ResCurrencyRateProvider(models.Model):
             direct = rate.get("direct", None)
             if inverted is None and direct is None:
                 raise UserError(
-                    _("Invalid rate from %(provider)s for %(currency)s : %(rate)s")
+                    _("Invalid rate from %(provider)s for %(currency)s: %(rate)s")
                     % {"provider": self.name, "currency": currency.name, "rate": rate}
                 )
             elif inverted is None:

--- a/currency_rate_update/security/res_currency_rate_provider.xml
+++ b/currency_rate_update/security/res_currency_rate_provider.xml
@@ -7,7 +7,6 @@
     <record id="res_currency_rate_provider_multicompany" model="ir.rule">
         <field name="name">Current Rates Provider multi-company</field>
         <field name="model_id" ref="model_res_currency_rate_provider" />
-        <field eval="True" name="global" />
         <field name="domain_force">
             ['|',('company_id','=',False),('company_id','in',company_ids)]
         </field>


### PR DESCRIPTION
I found these bad string while translating the module to French.
Also, no need to set global=True on ir.rule, because it is a computed field, https://github.com/odoo/odoo/blob/16.0/odoo/addons/base/models/ir_rule.py#L52