### PR TITLE
[14.0][FIX] currency_monthly_rate: fix category_id

### DIFF
--- a/currency_monthly_rate/security/res_groups.xml
+++ b/currency_monthly_rate/security/res_groups.xml
@@ -2,7 +2,7 @@
 <odoo>
     <record id="monthly_rates_group" model="res.groups">
         <field name="name">Monthly currency rates</field>
-        <field name="category_id" ref="base.module_category_accounting_and_finance" />
+        <field name="category_id" ref="base.module_category_accounting" />
         <field name="implied_ids" eval="[(4, ref('base.group_multi_currency'))]" />
     </record>
 


### PR DESCRIPTION
- Changed the security/category_id from module_category_accounting_and_finance to module_category_accounting.

This issue was noticed in a runboat that depends on the 'currency_monthly_rate' module, thus it pointed out the error below.

`Traceback (most recent call last):
  File "/opt/odoo/odoo/tools/convert.py", line 677, in _tag_root
    f(rec)
  File "/opt/odoo/odoo/tools/convert.py", line 564, in _tag_record
    f_val = self.id_get(f_ref)
  File "/opt/odoo/odoo/tools/convert.py", line 660, in id_get
    res = self.model_id_get(id_str, raise_if_not_found)
  File "/opt/odoo/odoo/tools/convert.py", line 666, in model_id_get
    return self.env['ir.model.data'].xmlid_to_res_model_res_id(id_str, raise_if_not_found=raise_if_not_found)
  File "/opt/odoo/odoo/addons/base/models/ir_model.py", line 1945, in xmlid_to_res_model_res_id
    return self.xmlid_lookup(xmlid)[1:3]
  File "<decorator-gen-35>", line 2, in xmlid_lookup
  File "/opt/odoo/odoo/tools/cache.py", line 90, in lookup
    value = d[key] = self.method(*args, **kwargs)
  File "/opt/odoo/odoo/addons/base/models/ir_model.py", line 1938, in xmlid_lookup
    raise ValueError('External ID not found in the system: %s' % xmlid)
ValueError: External ID not found in the system: base.module_category_accounting_and_finance
`

cc @marcelsavegnago @douglascstd 