### PR TITLE
[17.0][IMP] currency_rate_update: Remove DeprecationWarning: XML declarations in HTML module descriptions

### DIFF
--- a/currency_rate_update/static/description/index.html
+++ b/currency_rate_update/static/description/index.html
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>


### PR DESCRIPTION
Remove DeprecationWarning: XML declarations in HTML module descriptions

`WARNING devel py.warnings: /opt/odoo/custom/src/odoo/odoo/addons/base/models/ir_module.py:178: DeprecationWarning: XML declarations in HTML module descriptions are deprecated since Odoo 17, currency_rate_update can just have a UTF8 description with not need for a declaration.`

@Tecnativa