### PR TITLE
[16.0] pre-commit: bump setuptools-odoo to 3.3.2 to fix pkg_resources ImportError

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -140,7 +140,7 @@ repos:
           - --settings=.
         exclude: /__init__\.py$
   - repo: https://github.com/acsone/setuptools-odoo
-    rev: 3.1.8
+    rev: 3.3.2
     hooks:
       - id: setuptools-odoo-make-default
       - id: setuptools-odoo-get-requirements


### PR DESCRIPTION
## Summary

\`setuptools-odoo\` 3.1.8 imports \`pkg_resources\`, which is no longer available in \`setuptools >= 81\`. As a result, the \`setuptools-odoo-make-default\` and \`setuptools-odoo-get-requirements\` pre-commit hooks now fail on every PR opened against this branch with:

\`\`\`
ModuleNotFoundError: No module named 'pkg_resources'
\`\`\`

Example failure on a recent PR: https://github.com/OCA/currency/actions/runs/25795732013/job/75772439565

## Fix

Bump \`acsone/setuptools-odoo\` from \`3.1.8\` to \`3.3.2\`, which uses \`importlib.metadata\` instead of \`pkg_resources\`. Other OCA 16.0 repositories already moved to 3.3.2:

- OCA/server-tools (16.0)
- OCA/web (16.0)
- OCA/partner-contact (16.0)
- OCA/account-invoicing (16.0)

## Test plan

- [ ] CI green on this PR.
- [ ] Other open PRs against 16.0 (e.g. #216) can rebase and have pre-commit pass.