### PR TITLE
[14.0] pre-commit: bump setuptools-odoo to 3.3.2 to fix pkg_resources ImportError

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -140,7 +140,7 @@ repos:
           - --settings=.
         exclude: /__init__\.py$
   - repo: https://github.com/acsone/setuptools-odoo
-    rev: 3.1.8
+    rev: 3.3.2
     hooks:
       - id: setuptools-odoo-make-default
       - id: setuptools-odoo-get-requirements


### PR DESCRIPTION
`setuptools-odoo` 3.1.8 imports the removed `pkg_resources` module, so the `setuptools-odoo-make-default` and `setuptools-odoo-get-requirements` pre-commit hooks fail with `ModuleNotFoundError: No module named 'pkg_resources'` on recent setuptools (>= 81). The `pre-commit` check is therefore red on every PR currently opened against `14.0`.

Bump the hook to `3.3.2`, the same fix as #217 (16.0).
