### PR TITLE
[16.0] pre-commit: bump setuptools-odoo to 3.3.2

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -140,7 +140,7 @@ repos:
           - --settings=.
         exclude: /__init__\.py$
   - repo: https://github.com/acsone/setuptools-odoo
-    rev: 3.1.8
+    rev: 3.3.2
     hooks:
       - id: setuptools-odoo-make-default
       - id: setuptools-odoo-get-requirements


### PR DESCRIPTION
The `setuptools-odoo` 3.1.8 hooks import `pkg_resources`, which is removed in
recent `setuptools`, so `setuptools-odoo-make-default` and
`setuptools-odoo-get-requirements` crash with
`ModuleNotFoundError: No module named 'pkg_resources'` and the pre-commit job
fails on every PR targeting 16.0. Bumping to 3.3.2 (which dropped the
`pkg_resources` import) fixes it.

Same change as #217 (17.0) and #221 (14.0).
