### PR TITLE
[FIX] currency_rate_update_xe: add User-Agent header to fix xe.com 403 blocking

### DIFF
--- a/currency_rate_update_xe/models/res_currency_rate_provider_XE.py
+++ b/currency_rate_update_xe/models/res_currency_rate_provider_XE.py
@@ -221,7 +221,7 @@ class ResCurrencyRateProviderXE(models.Model):
         self.ensure_one()
         if self.service != "XE":
             return super()._obtain_rates(base_currency, currencies, date_from, date_to)
-        base_url = "http://www.xe.com/currencytables"
+        base_url = "https://www.xe.com/currencytables"
         if date_from < date.today():
             return self._get_historical_rate(
                 base_url, currencies, date_from, date_to, base_currency
@@ -255,7 +255,24 @@ class ResCurrencyRateProviderXE(models.Model):
         url,
     ):
         try:
-            return requests.request("GET", url, timeout=10)
+            response = requests.request(
+                "GET",
+                url,
+                timeout=10,
+                headers={
+                    "User-Agent": (
+                        "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36"
+                        " (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36"
+                    )
+                },
+            )
+            response.raise_for_status()
+            return response
+        except requests.HTTPError as e:
+            raise UserError(
+                _("XE.com returned HTTP %s. Please contact your administrator.")
+                % e.response.status_code
+            ) from e
         except Exception as e:
             raise UserError(
                 _("Couldn't fetch data. Please contact your administrator.")


### PR DESCRIPTION
## Summary

- xe.com started blocking requests without a `User-Agent` header around May 2025, returning HTTP 403. The code sent requests with Python's default `python-requests/x.x.x` UA which is trivially bot-filtered.
- The `_parse_data` method silently returned an empty dict on a 403 page (0 rows found), so no rates were written and no error was raised — making the breakage invisible in logs.
- Switch `base_url` from `http://` to `https://` to avoid an unnecessary redirect on every call.

## Changes

- Add `User-Agent` browser header to `_request_data`
- Call `response.raise_for_status()` and handle `HTTPError` separately so HTTP-level failures surface as a meaningful `UserError` in Odoo instead of silently producing empty results
- Use `https://` for the base URL

## Test plan

- [ ] Configure a XE provider for EGP (or any currency) and trigger a manual update — rates should populate correctly
- [ ] Confirm the fix works for both `_get_latest_rate` and `_get_historical_rate` paths

🤖 Generated with [Claude Code](https://claude.ai/claude-code)