### PR TITLE
[14.0][FIX] currency_rate_update_transferwise: avoid a zero-length date window

### DIFF
--- a/currency_rate_update_transferwise/models/res_currency_rate_provider_TransferWise.py
+++ b/currency_rate_update_transferwise/models/res_currency_rate_provider_TransferWise.py
@@ -59,6 +59,13 @@ class ResCurrencyRateProviderTransferWise(models.Model):
             since = date_from
             until = since + step
             while since <= date_to:
+                # The API answers HTTP 400 when "from" equals "to". That is
+                # exactly the shape of a scheduled run once the rates are up
+                # to date: the provider then asks for the single missing day.
+                # Widening the window by one day is enough — the endpoint only
+                # ever returns the days it actually has, so no spurious rate
+                # is created.
+                window_end = max(min(until, date_to), since + timedelta(days=1))
                 url = (
                     "https://api.transferwise.com/v1/rates"
                     + "?from=%(from)s"
@@ -70,7 +77,7 @@ class ResCurrencyRateProviderTransferWise(models.Model):
                     "source": base_currency,
                     "target": currency,
                     "from": str(since),
-                    "to": str(min(until, date_to)),
+                    "to": str(window_end),
                 }
                 data = json.loads(self._transferwise_provider_retrieve(url))
                 if "error" in data and data["error"]:


### PR DESCRIPTION
## Problem

The provider builds its query with `"to": str(min(until, date_to))`. When the window would collapse — `date_from == date_to` — that yields `from == to`, and the API rejects it:

```
GET /v1/rates?from=2026-08-04&to=2026-08-04&source=USD&target=EUR&group=day
→ 400 Bad Request
```

Odoo then logs, once per scheduled run:

```
Currency Rate Provider "…" failed to obtain data since 2026-08-04 until 2026-08-04:
400 Client Error: Bad Request
```

## Why it went unnoticed

The failure is **intermittent by construction**. A single-day window only happens once the rates are already up to date — the steady state of a daily cron. As soon as two or more days are missing the window is valid again, the next run catches up, and the gap disappears from the rate table. On a production instance I found ~10 missing days over a 36-day span with no visible symptom other than these log lines.

## Fix

Widen the window by one day when it would collapse. Verified against the live API:

| window | response |
| --- | --- |
| `from=2026-08-04&to=2026-08-04` | **400** |
| `from=2026-08-04&to=2026-08-05` | 200 — returns the 4th only |
| `from=2026-08-05&to=2026-08-06` | 200 — returns the 5th only |
| `from=2026-08-06&to=2026-08-07` | 404 — window entirely in the future |

The endpoint only ever returns the days it actually has, so asking for one day ahead creates no spurious rate.

The same defect is present in the `currency_rate_update_wise` migration PRs (#222, #223, #224, #225, #232) and in #219; they carry the equivalent fix.